### PR TITLE
feat: add compact mode, CSL types, and type checking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: black lint test publish
+.PHONY: black lint test type publish
 
 format:
 	poetry run isort --profile black .
@@ -9,6 +9,9 @@ lint:
 
 test:
 	poetry run pytest
+
+type:
+	poetry run pyright
 
 publish:
 	poetry publish --build --dry-run

--- a/README.md
+++ b/README.md
@@ -18,40 +18,37 @@
 **Community**
 
 - 📚 [View the **documentation**](https://wowchemy.com/docs/content/publications/#import-from-bibtex) and usage guide below
-- 💬 [Chat with the **Wowchemy community**](https://discord.gg/z8wNYzb) or [**Hugo community**](https://discourse.gohugo.io)
+- 💬 [Chat with the **community**](https://discord.gg/z8wNYzb)
 - 🐦 Twitter: [@wowchemy](https://twitter.com/wowchemy) [@GeorgeCushen](https://twitter.com/GeorgeCushen) [#MadeWithAcademic](https://twitter.com/search?q=(%23MadeWithWowchemy%20OR%20%23MadeWithAcademic)&src=typed_query)
 
 **❤️ Support this open-source software**
 
-To help us develop this converter tool and the associated Wowchemy software sustainably under the MIT license, we ask all individuals and businesses that use it to help support its ongoing maintenance and development via sponsorship and contributing.
+To help us develop this converter tool and the associated Wowchemy open source software sustainably under the MIT license, we ask all individuals and businesses that use it to help support its ongoing maintenance and development via sponsorship and contributing.
 
-Support development of the Academic CLI:
+Support this open science movement:
 
+  - ⭐️ [**Star** this project on GitHub](https://github.com/wowchemy/bibtex-to-markdown)
   - ❤️ [Become a **GitHub Sponsor** and **unlock perks**](https://github.com/sponsors/gcushen)
   - ☕️ [**Donate a coffee**](https://github.com/sponsors/gcushen)
   - 👩‍💻 [**Contribute**](#contribute)
 
-## Prerequisites
-
-1. Install [Python 3.11+](https://realpython.com/installing-python/) if it’s not already installed
-
-### For Building a Website with Hugo (Optional)
-
-1. Create a [Hugo](https://gohugo.io) website such as by using the [Hugo Academic Starter](https://github.com/wowchemy/starter-hugo-academic) template for the [Wowchemy](https://wowchemy.com) website builder
-1. [Download your site from GitHub, installing Hugo and its dependencies](https://wowchemy.com/docs/getting-started/install-hugo-extended/)
-1. [Version control](https://guides.github.com/introduction/git-handbook/#version-control) your website
-   - Ideally, version control your site with [Git](http://rogerdudler.github.io/git-guide/) so that you can review the proposed changes and accept or reject them without risking breaking your site
-   - Otherwise, if not using Git, **backup your site folder** prior to running this tool
-
 ## Installation
 
-Open your Terminal or Command Prompt app and install the Academic CLI tool:
+Open your **Terminal** or **Command Prompt** app and enter one of the installation commands below.
+
+### With Pipx
+
+For the **easiest** installation, install with [Pipx](https://pypa.github.io/pipx/): 
+
+    pipx install academic
+
+Pipx will **automatically install the required Python version for you** in a dedicated environment.
+
+### With Pip
+
+ To install using the Python's Pip tool, ensure you have [Python 3.11+](https://realpython.com/installing-python/) installed and then run:
 
     pip3 install -U academic
-    
-Or, help test the latest development version:
-
-    pip3 install -U git+https://github.com/wowchemy/hugo-academic-cli.git
 
 ## Usage
 
@@ -61,28 +58,24 @@ Use the `cd` command to navigate to the folder containing your Bibtex file:
 
     cd <MY_BIBTEX_FOLDER>
 
-**Import publications:**
+### Import publications
 
-Say we downloaded our publications from our reference manager, such as Zotero, to a file named `my_publications.bib` within the website folder. We can import them into the default `content/publication/` folder with:
+Say we downloaded our publications to a file named `my_publications.bib` within the website folder, let's import them into the `content/publication/` folder:
 
-    academic import --bibtex my_publications.bib
-
-**Import publications to a specific folder (e.g. `content/zh/publication`):**
-
-Say our site has multiple languages, we may want to output the publications to a specific folder with:
-
-    academic import --bibtex my_publications.bib --publication-dir content/zh/publication/
+    academic import my_publications.bib content/publication/ --compact
 
 Optional arguments:
 
-* `--publication-dir PUBLICATION_DIR` Folder to import publications to (defaults to `content/publication`)
+* `--compact` Generate minimal markdown without comments or empty keys
 * `--overwrite` Overwrite any existing publications in the output folder
 * `--normalize` Normalize tags by converting them to lowercase and capitalizing the first letter (e.g. "sciEnCE" -> "Science")
-* `--featured` Flag these publications as *featured* (to appear in *Featured Publications* widget)
+* `--featured` Flag these publications as *featured* (to appear in your website's *Featured Publications* section)
 * `--verbose` or `-v` Show verbose messages
 * `--help` Help
 
-After importing publications, [a full text PDF and image can be associated with each item and further details added via extra parameters](https://wowchemy.com/docs/content/publications/).
+### Import full text and cover image
+
+After importing publications, [a full text and image can be associated with each item and further details added via extra parameters](https://wowchemy.com/docs/content/publications/).
 
 ## Contribute
 
@@ -97,13 +90,20 @@ For local development, clone this repository and use Poetry to install and run t
     git clone https://github.com/wowchemy/bibtex-to-markdown.git
     cd bibtex-to-markdown
     poetry install
-    poetry run academic import --bibtex=tests/data/article.bib --publication-dir=debug --overwrite
+    poetry run academic import tests/data/article.bib output/ --overwrite --compact
 
-Preparing a contribution:
+When preparing a contribution, run the following checks and ensure that they all pass:
 
 - Lint: `make lint`
 - Format: `make format`
 - Test: `make test`
+- Type check: `make type`
+- 
+### Help beta test the dev version
+
+You can help test the latest development version by installing the latest `main` branch from GitHub:
+
+    pip3 install -U git+https://github.com/wowchemy/bibtex-to-markdown.git
 
 ## License
 

--- a/academic/cli.py
+++ b/academic/cli.py
@@ -3,7 +3,6 @@
 import argparse
 import importlib.metadata
 import logging
-import os
 import sys
 from argparse import RawTextHelpFormatter
 
@@ -18,12 +17,9 @@ logging.basicConfig(
 log = logging.getLogger(__name__)
 
 
-class AcademicError(Exception):
-    pass
-
-
 def main():
-    parse_args(sys.argv[1:])  # Strip command name, leave just args.
+    # Strip command name (currently `academic`) and feed arguments to the parser
+    parse_args(sys.argv[1:])
 
 
 def parse_args(args):
@@ -38,17 +34,12 @@ def parse_args(args):
     subparsers = parser.add_subparsers(help="Sub-commands", dest="command")
 
     # Sub-parser for import command.
-    parser_a = subparsers.add_parser("import", help="Import data into Academic")
-    parser_a.add_argument("--bibtex", required=False, type=str, help="File path to your BibTeX file")
-    parser_a.add_argument(
-        "--publication-dir",
-        required=False,
-        type=str,
-        default=os.path.join("content", "publication"),
-        help="Path to import publications to (default `content/publication`)",
-    )
+    parser_a = subparsers.add_parser("import", help="Import content into your website or book")
+    parser_a.add_argument("input", type=str, help="File path to your BibTeX file")
+    parser_a.add_argument("output", type=str, help="Path to import publications to (e.g. `content/publication/`)")
     parser_a.add_argument("--featured", action="store_true", help="Flag publications as featured")
     parser_a.add_argument("--overwrite", action="store_true", help="Overwrite existing publications")
+    parser_a.add_argument("--compact", action="store_true", help="Generate minimal markdown")
     parser_a.add_argument(
         "--normalize",
         action="store_true",
@@ -71,17 +62,19 @@ def parse_args(args):
         parser.exit()
     else:
         # The command has been recognised, proceed to parse it.
-        if known_args.command and known_args.verbose:
-            # Set logging level to debug if verbose mode activated.
-            logging.getLogger().setLevel(logging.DEBUG)
-        elif known_args.command and known_args.bibtex:
+        if known_args.command:
+            if known_args.verbose:
+                # Set logging level to debug if verbose mode activated.
+                logging.getLogger().setLevel(logging.DEBUG)
+
             # Run command to import bibtex.
             import_bibtex(
-                known_args.bibtex,
-                pub_dir=known_args.publication_dir,
+                known_args.input,
+                pub_dir=known_args.output,
                 featured=known_args.featured,
                 overwrite=known_args.overwrite,
                 normalize=known_args.normalize,
+                compact=known_args.compact,
                 dry_run=known_args.dry_run,
             )
 

--- a/academic/generate_markdown.py
+++ b/academic/generate_markdown.py
@@ -1,52 +1,122 @@
 from pathlib import Path
 
-from ruamel.yaml import YAML
-
-yaml = YAML()
+import ruamel.yaml
 
 
-class EditableFM:
-    def __init__(self, base_path: Path, delim: str = "---", dry_run: bool = False):
+class GenerateMarkdown:
+    """
+    Load a Markdown file, enable its YAML front matter to be edited (currently, directly via `self.yaml[...]`), and then save it.
+    """
+
+    def __init__(self, base_path: Path, delim: str = "---", dry_run: bool = False, compact: bool = False):
+        """
+        Initialise the class.
+
+        Args:
+            base_path: the folder to save the Markdown file to
+            delim: the front matter delimiter, i.e. `---` for YAML front matter
+            dry_run: whether to actually save the output to file
+            compact: whether to strip comments, line breaks, and empty keys from the generated Markdown
+        """
         self.base_path = base_path
         if delim != "---":
             raise NotImplementedError("Currently, YAML is the only supported front-matter format.")
         self.delim = delim
-        self.fm = []
+        self.yaml = {}
         self.content = []
         self.path = ""
         self.dry_run = dry_run
+        self.compact = compact
+        # We use Ruamel's default round-trip loading to preserve key order and comments, rather than `YAML(typ='safe')`
+        self.yaml_parser = ruamel.yaml.YAML()
 
     def load(self, file: Path):
-        self.fm = []
+        """
+        Load the Markdown file to edit.
+
+        Args:
+            file: the Markdown filename to load. By default, it will be a copy of the Markdown template file saved to the output folder.
+
+        Returns: n/a - directly saves output to `self.yaml`
+
+        """
+        front_matter_text = []
+        self.yaml = {}
         self.content = []
         self.path = self.base_path / file
         if self.dry_run and not self.path.exists():
-            self.fm = dict()
+            self.yaml = dict()
             return
 
         with self.path.open("r", encoding="utf-8") as f:
             lines = f.readlines()
 
+        # Detect both the YAML front matter and the Markdown content in the template
         delims_seen = 0
         for line in lines:
             if line.startswith(self.delim):
                 delims_seen += 1
             else:
                 if delims_seen < 2:
-                    self.fm.append(line)
-                else:
+                    front_matter_text.append(line)
+                # In Compact mode, we don't add any placeholder content to the page
+                elif not self.compact:
+                    # Append any Markdown content from the template body (after the YAML front matter)
                     self.content.append(line)
 
-        # Parse YAML, trying to preserve comments and whitespace
-        self.fm = yaml.load("".join(self.fm))
+        # Parse YAML, trying to preserve key order, comments, and whitespace
+        self.yaml = self.yaml_parser.load("".join(front_matter_text))
+
+    def recursive_delete_comment_attribs(self, d):
+        """
+        Delete comments from the YAML template for Compact mode
+
+        Args:
+            d: the named attribute to delete from the YAML dict
+        """
+        if isinstance(d, dict):
+            for k, v in d.items():
+                self.recursive_delete_comment_attribs(k)
+                self.recursive_delete_comment_attribs(v)
+        elif isinstance(d, list):
+            for elem in d:
+                self.recursive_delete_comment_attribs(elem)
+        try:
+            # literal scalarstring might have comment associated with them
+            attr = "comment" if isinstance(d, ruamel.yaml.scalarstring.ScalarString) else ruamel.yaml.comments.Comment.attrib  # type: ignore
+            delattr(d, attr)
+        except AttributeError:
+            pass
 
     def dump(self):
+        """
+        Save the generated markdown to file.
+        """
         assert self.path, "You need to `.load()` first."
         if self.dry_run:
             return
 
         with open(self.path, "w", encoding="utf-8") as f:
             f.write("{}\n".format(self.delim))
-            yaml.dump(self.fm, f)
+            if self.compact:
+                # For compact output, strip comments, new lines, and empty keys
+                # Strip `image` key in Compact mode as it cannot currently be set via Bibtex, it's just set in template.
+                # Note: a better implementation may be just to start with a different template for Compact mode,
+                # rather than remove items from the detailed template.
+                self.recursive_delete_comment_attribs(self.yaml)
+                elems_to_delete = []
+                for elem in self.yaml:
+                    if (
+                        self.yaml[elem] is None
+                        or self.yaml[elem] == ""
+                        or self.yaml[elem] == []
+                        or (elem == "featured" and self.yaml[elem] is False)
+                        or (elem == "image")
+                    ):
+                        elems_to_delete.append(elem)
+                for elem in elems_to_delete:
+                    del self.yaml[elem]
+                del elems_to_delete
+            self.yaml_parser.dump(self.yaml, f)
             f.write("{}\n".format(self.delim))
             f.writelines(self.content)

--- a/academic/publication_type.py
+++ b/academic/publication_type.py
@@ -1,34 +1,18 @@
-from enum import Enum
-
-
-# Map BibTeX to Academic publication types.
-class PublicationType(Enum):
-    Uncategorized = 0
-    ConferencePaper = 1
-    JournalArticle = 2
-    Preprint = 3
-    Report = 4
-    Book = 5
-    BookSection = 6
-    Thesis = 7  # (v4.2+ required)
-    Patent = 8  # (v4.2+ required)
-
-
-PUB_TYPES = {
-    "article": PublicationType.JournalArticle,
-    "book": PublicationType.Book,
-    "conference": PublicationType.ConferencePaper,
-    "inbook": PublicationType.BookSection,
-    "incollection": PublicationType.BookSection,
-    "inproceedings": PublicationType.ConferencePaper,
-    "manual": PublicationType.Report,
-    "mastersthesis": PublicationType.Thesis,
-    "misc": PublicationType.Uncategorized,
-    "patent": PublicationType.Patent,
-    "phdthesis": PublicationType.Thesis,
-    "proceedings": PublicationType.Uncategorized,
-    "report": PublicationType.Report,
-    "thesis": PublicationType.Thesis,
-    "techreport": PublicationType.Report,
-    "unpublished": PublicationType.Preprint,
+# Map BibTeX publication types to universal CSL types
+PUB_TYPES_BIBTEX_TO_CSL = {
+    "article": "article-journal",
+    "book": "book",
+    "conference": "paper-conference",
+    "inbook": "chapter",
+    "incollection": "chapter",
+    "inproceedings": "paper-conference",
+    "manual": "book",
+    "mastersthesis": "thesis",
+    "patent": "patent",
+    "phdthesis": "thesis",
+    "proceedings": "book",
+    "report": "report",
+    "thesis": "thesis",
+    "techreport": "report",
+    "unpublished": "manuscript",
 }

--- a/academic/templates/publication.md
+++ b/academic/templates/publication.md
@@ -2,28 +2,29 @@
 title: 'Publication title'
 
 # Authors
-# If you created a profile for a user (e.g. the default `admin` user), write the username (folder name) here
-# and it will be replaced with their full name and linked to their profile.
+# A YAML list of author names
+# If you created a profile for a user (e.g. the default `admin` user at `content/authors/admin/`), 
+# write the username (folder name) here, and it will be replaced with their full name and linked to their profile.
 authors: []
 
 # Author notes (such as 'Equal Contribution')
+# A YAML list of notes for each author in the above `authors` list
 author_notes: []
 
 date: '2013-07-01T00:00:00Z'
-doi: ''
 
-# Schedule page publish date (NOT publication's date).
+# Date to publish webpage (NOT necessarily Bibtex publication's date).
 publishDate: '2017-01-01T00:00:00Z'
 
 # Publication type.
-# Legend: 0 = Uncategorized; 1 = Conference paper; 2 = Journal article;
-# 3 = Preprint / Working Paper; 4 = Report; 5 = Book; 6 = Book section;
-# 7 = Thesis; 8 = Patent
-publication_types: ['1']
+# A single CSL publication type but formatted as a YAML list (for Hugo requirements).
+publication_types: ['paper-conference']
 
 # Publication name and optional abbreviated publication name.
 publication: ''
 publication_short: ''
+
+doi: ''
 
 abstract: ''
 

--- a/academic/utils.py
+++ b/academic/utils.py
@@ -1,0 +1,2 @@
+class AcademicError(Exception):
+    pass

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,12 +2,12 @@
 
 [[package]]
 name = "bibtexparser"
-version = "1.4.0"
+version = "1.4.1"
 description = "Bibtex parser for python 3"
 optional = false
 python-versions = "*"
 files = [
-    {file = "bibtexparser-1.4.0.tar.gz", hash = "sha256:ca7ce2bc34e7c48a678dd49416429bb567441f26dbb13b3609082d8cd109ace6"},
+    {file = "bibtexparser-1.4.1.tar.gz", hash = "sha256:e00e29e24676c4808e0b4333b37bb55cca9cbb7871a56f63058509281588d789"},
 ]
 
 [package.dependencies]
@@ -149,6 +149,20 @@ files = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.8.0"
+description = "Node.js virtual environment builder"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*"
+files = [
+    {file = "nodeenv-1.8.0-py2.py3-none-any.whl", hash = "sha256:df865724bb3c3adc86b3876fa209771517b0cfe596beff01a92700e0e8be4cec"},
+    {file = "nodeenv-1.8.0.tar.gz", hash = "sha256:d51e0c37e64fbf47d017feac3145cdbb58836d7eee8c6f6d3b6880c5456227d2"},
+]
+
+[package.dependencies]
+setuptools = "*"
+
+[[package]]
 name = "packaging"
 version = "23.1"
 description = "Core utilities for Python packages"
@@ -237,6 +251,24 @@ files = [
 diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
+name = "pyright"
+version = "1.1.329"
+description = "Command line wrapper for pyright"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pyright-1.1.329-py3-none-any.whl", hash = "sha256:c16f88a7ac14ddd0513e62fec56d69c37e3c6b412161ad16aa23a9c7e3dabaf4"},
+    {file = "pyright-1.1.329.tar.gz", hash = "sha256:5baf82ff5ecb8c8b3ac400e8536348efbde0b94a09d83d5b440c0d143fd151a8"},
+]
+
+[package.dependencies]
+nodeenv = ">=1.6.0"
+
+[package.extras]
+all = ["twine (>=3.4.1)"]
+dev = ["twine (>=3.4.1)"]
+
+[[package]]
 name = "pytest"
 version = "7.4.2"
 description = "pytest: simple powerful testing with Python"
@@ -320,7 +352,23 @@ files = [
     {file = "ruamel.yaml.clib-0.2.7.tar.gz", hash = "sha256:1f08fd5a2bea9c4180db71678e850b995d2a5f4537be0e94557668cf0f5f9497"},
 ]
 
+[[package]]
+name = "setuptools"
+version = "68.2.2"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "setuptools-68.2.2-py3-none-any.whl", hash = "sha256:b454a35605876da60632df1a60f736524eb73cc47bbc9f3f1ef1b644de74fd2a"},
+    {file = "setuptools-68.2.2.tar.gz", hash = "sha256:4ac1475276d2f1c48684874089fefcd83bd7162ddaafb81fac866ba0db282a87"},
+]
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.1)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11.5"
-content-hash = "d997aa2846f05fed79ec45bb6c5ad983d3658c8adc0f3c8d5fce40af2efcef03"
+content-hash = "eb0348254cccd113e891cb30698ecacd9421cc56a7a3a06f96089ad2c2d1165c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,14 +17,18 @@ academic = "academic.cli:main"
 
 [tool.poetry.dependencies]
 python = ">=3.11.5"
-bibtexparser = "^1.4.0"
-"ruamel.yaml" = "^0.17.32"
+bibtexparser = "~1.4"
+"ruamel.yaml" = "~0.17"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.9.1"
 flake8 = "^6.1.0"
 isort = "^5.12.0"
 pytest = "^7.4.2"
+pyright = "^1.1.329"
 
 [tool.black]
 line-length = 150  # Match Flake8 setting in `.flake8` file
+
+[tool.pyright]
+include = ["academic"]

--- a/tests/data/book.bib
+++ b/tests/data/book.bib
@@ -8,3 +8,9 @@ Paragraph two.
 
 Paragraph three.},
 }
+@manual{MyManual,
+  author = {Nelson Bigetti},
+  title = {Long manual title},
+  shorttitle = {Short manual title},
+  date = {2019-08},
+}

--- a/tests/data/report.bib
+++ b/tests/data/report.bib
@@ -16,9 +16,3 @@
   number = {TR-2345},
   type = {Technical Report}
 }
-@manual{MyManual,
-  author = {Nelson Bigetti},
-  title = {Long manual title},
-  shorttitle = {Short manual title},
-  date = {2019-08},
-}

--- a/tests/test_bibtex_import.py
+++ b/tests/test_bibtex_import.py
@@ -5,16 +5,16 @@ import bibtexparser
 from bibtexparser.bparser import BibTexParser
 
 from academic import cli, import_bibtex
-from academic.generate_markdown import EditableFM
+from academic.generate_markdown import GenerateMarkdown
 
 bibtex_dir = Path(__file__).parent / "data"
 
 
 def test_bibtex_import():
-    cli.parse_args(["import", "--dry-run", "--bibtex", "tests/data/article.bib"])
+    cli.parse_args(["import", "--dry-run", "tests/data/article.bib", "content/publication/"])
 
 
-def _process_bibtex(file, expected_count=1) -> "typing.List[EditableFM]":
+def _process_bibtex(file, expected_count=1) -> "typing.List[GenerateMarkdown]":
     """
     Parse a BibTeX .bib file and return the parsed metadata
     :param file: The .bib file to parse
@@ -33,11 +33,11 @@ def _process_bibtex(file, expected_count=1) -> "typing.List[EditableFM]":
         return results
 
 
-def _test_publication_type(metadata: EditableFM, expected_type: import_bibtex.PublicationType):
+def _test_publication_type(metadata: GenerateMarkdown, expected_type: str):
     """
     Check that the publication_types field of the parsed metadata is set to the expected type.
     """
-    assert metadata.fm["publication_types"] == [str(expected_type.value)]
+    assert metadata.yaml["publication_types"] == [expected_type]
 
 
 def test_bibtex_types():
@@ -45,9 +45,10 @@ def test_bibtex_types():
     This test uses the import_bibtex functions to parse a .bib file and checks that the
     resulting metadata has the correct publication type set.
     """
-    _test_publication_type(_process_bibtex("article.bib")[0], import_bibtex.PublicationType.JournalArticle)
-    for metadata in _process_bibtex("report.bib", expected_count=3):
-        _test_publication_type(metadata, import_bibtex.PublicationType.Report)
+    _test_publication_type(_process_bibtex("article.bib")[0], "article-journal")
+    for metadata in _process_bibtex("report.bib", expected_count=2):
+        _test_publication_type(metadata, "report")
     for metadata in _process_bibtex("thesis.bib", expected_count=3):
-        _test_publication_type(metadata, import_bibtex.PublicationType.Thesis)
-    _test_publication_type(_process_bibtex("book.bib")[0], import_bibtex.PublicationType.Book)
+        _test_publication_type(metadata, "thesis")
+    for metadata in _process_bibtex("book.bib", expected_count=2):
+        _test_publication_type(metadata, "book")


### PR DESCRIPTION
changes

- standardize publication types by adopting universal CSL publication types
- add compact mode (`--compact`) to generate minimal output (strips comments, line breaks, and empty keys)
- make input (bibtex) and output (publication folder) positional args rather than options (`--...`) as they are always required
- add Python static type checking with pyright (to run: `make type`)
- improve documentation (more docstrings and add easier installation method with pipx to Readme)